### PR TITLE
TEST / ci: commit built docs to pouchdb-www repo, asf-site branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,3 +30,36 @@ jobs:
         with:
           node-version: 24
       - run: BUILD=1 npm run build-site
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Checkout pouchdb-www repo
+        uses: actions/checkout@v4
+        with:
+          repository: neighbourhoodie/pouchdb-www
+          ref: asf-site
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          path: checked-out-pouchdb-www
+          fetch-depth: 0
+      - name: Commit and push if changed
+        run: |
+          cd checked-out-pouchdb-www
+          git config user.name "CI"
+          git config user.email "ci@users.noreply.github.com"
+
+          # Juuust in case
+          git checkout asf-site
+
+          git rm -rf . || true
+
+          cp -R ../docs/_site/. .
+
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Committing changes…"
+            git add -A
+            git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+            git push git@github.com:neighbourhoodie/pouchdb-www.git asf-site --force
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           repository: apache/pouchdb-site
           ref: asf-site
-          ssh-key: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
           path: checked-out-pouchdb-site
           fetch-depth: 0
       - name: Commit and push if changed
@@ -36,6 +35,10 @@ jobs:
           POUCHDB_WEBSITE_BUILD: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
         run: |
           cd checked-out-pouchdb-site
+
+          echo "Git remotes:"
+          git remote -v
+
           git config url."https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/".insteadOf "https://github.com/"
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git config user.name ${{ github.actor }}
@@ -47,13 +50,11 @@ jobs:
 
           cp -R ../docs/_site/. .
 
-          git remote -v
-
           if [[ -n $(git status --porcelain) ]]; then
             echo "Committing changes…"
             git add -A
             git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            git push origin asf-site --force
+            GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin asf-site --force
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,11 +30,24 @@ jobs:
           ref: asf-site
           path: checked-out-pouchdb-site
           fetch-depth: 0
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.POUCHDB_WEBSITE_BUILD }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - name: Configure SSH for GitHub
+        run: |
+          echo "Host github.com
+            IdentityFile ~/.ssh/id_rsa
+            IdentitiesOnly yes" >> ~/.ssh/config
       - name: Commit and push if changed
         env:
           POUCHDB_WEBSITE_BUILD: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
         run: |
           cd checked-out-pouchdb-site
+
+          git remote set-url origin git@github.com:apache/pouchdb-site.git
 
           echo "Git remotes:"
           git remote -v

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,12 +52,12 @@ jobs:
           echo "Git remotes:"
           git remote -v
 
-          git config url."https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/".insteadOf "https://github.com/"
+          # git config url."https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/".insteadOf "https://github.com/"
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git config user.name ${{ github.actor }}
 
           # Juuust in case
-          git checkout asf-site
+          GIT_TRACE=1 GIT_CURL_VERBOSE=1 git checkout asf-site
 
           git rm -rf . || true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,6 @@ name: PouchDB Docs
 
 on:
   push:
-    paths:
-      - '.github/actions/**'
-      - '.github/workflows/docs.yml'
-      - 'package.json'
-      - 'bin/**'
-      - 'docs/**'
-  pull_request:
     branches: [master]
     paths:
       - '.github/actions/**'
@@ -54,11 +47,13 @@ jobs:
 
           cp -R ../docs/_site/. .
 
+          git remote -v
+
           if [[ -n $(git status --porcelain) ]]; then
             echo "Committing changes…"
             git add -A
             git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            git push git@github.com:apache/pouchdb-site.git asf-site --force
+            git push origin asf-site --force
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,18 +33,18 @@ jobs:
       - name: Setup SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Checkout pouchdb-www repo
+          ssh-private-key: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
+      - name: Checkout pouchdb-site repo
         uses: actions/checkout@v4
         with:
-          repository: neighbourhoodie/pouchdb-www
+          repository: apache/pouchdb-site
           ref: asf-site
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-          path: checked-out-pouchdb-www
+          ssh-key: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
+          path: checked-out-pouchdb-site
           fetch-depth: 0
       - name: Commit and push if changed
         run: |
-          cd checked-out-pouchdb-www
+          cd checked-out-pouchdb-site
           git config user.name "CI"
           git config user.email "ci@users.noreply.github.com"
 
@@ -59,7 +59,7 @@ jobs:
             echo "Committing changes…"
             git add -A
             git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            git push git@github.com:neighbourhoodie/pouchdb-www.git asf-site --force
+            git push git@github.com:apache/pouchdb-site.git asf-site --force
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
   test-docs:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
+      - name: Checkout PouchDB repo
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -30,10 +30,6 @@ jobs:
         with:
           node-version: 24
       - run: BUILD=1 npm run build-site
-      - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
       - name: Checkout pouchdb-site repo
         uses: actions/checkout@v4
         with:
@@ -43,10 +39,13 @@ jobs:
           path: checked-out-pouchdb-site
           fetch-depth: 0
       - name: Commit and push if changed
+        env:
+          POUCHDB_WEBSITE_BUILD: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
         run: |
           cd checked-out-pouchdb-site
-          git config user.name "CI"
-          git config user.email "ci@users.noreply.github.com"
+          git config url."https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/".insteadOf "https://github.com/"
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git config user.name ${{ github.actor }}
 
           # Juuust in case
           git checkout asf-site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,34 +30,19 @@ jobs:
           ref: asf-site
           path: checked-out-pouchdb-site
           fetch-depth: 0
-      - name: Set up SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.POUCHDB_WEBSITE_BUILD }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - name: Configure SSH for GitHub
-        run: |
-          echo "Host github.com
-            IdentityFile ~/.ssh/id_rsa
-            IdentitiesOnly yes" >> ~/.ssh/config
       - name: Commit and push if changed
         env:
           POUCHDB_WEBSITE_BUILD: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
         run: |
           cd checked-out-pouchdb-site
 
-          git remote set-url origin git@github.com:apache/pouchdb-site.git
+          git remote add deploy https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/apache/pouchdb-site
 
           echo "Git remotes:"
           git remote -v
 
-          # git config url."https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/".insteadOf "https://github.com/"
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git config user.name ${{ github.actor }}
-
-          # Juuust in case
-          GIT_TRACE=1 GIT_CURL_VERBOSE=1 git checkout asf-site
 
           git rm -rf . || true
 
@@ -67,7 +52,7 @@ jobs:
             echo "Committing changes…"
             git add -A
             git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin asf-site --force
+            GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push deploy asf-site --force
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,13 +30,14 @@ jobs:
           ref: asf-site
           path: checked-out-pouchdb-site
           fetch-depth: 0
+          token: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
       - name: Commit and push if changed
         env:
           POUCHDB_WEBSITE_BUILD: ${{ secrets.POUCHDB_WEBSITE_BUILD }}
         run: |
           cd checked-out-pouchdb-site
 
-          git remote add deploy https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/apache/pouchdb-site
+          # git remote add deploy https://asf-ci-deploy:$POUCHDB_WEBSITE_BUILD@github.com/apache/pouchdb-site
 
           echo "Git remotes:"
           git remote -v
@@ -52,7 +53,7 @@ jobs:
             echo "Committing changes…"
             git add -A
             git commit -m "Deploy site from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push deploy asf-site --force
+            GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin asf-site --force
           else
             echo "No changes to commit"
           fi

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Using PouchDB
 
 To get started using PouchDB, check out the [web site](https://pouchdb.com) and [API documentation](https://pouchdb.com/api.html).
 
+Deploying the Documentation Site www.pouchdb.com
+------------------------------------------------
+
+Doc website deployment is handled automatically once the changes land in `master`.
+
 Getting Help
 ------------
 


### PR DESCRIPTION
This extends the `docs.yml` workflow to take the build artifacts and commit them into the `asf-site` branch of the `pouchdb-www` repo, for testing this is currently aimed at the repo in the neighbourhoodie org. 