### PR TITLE
Fix docs edit path

### DIFF
--- a/docs/_includes/edit_button.html
+++ b/docs/_includes/edit_button.html
@@ -1,4 +1,4 @@
-{% assign pagePath = page.inputPath | replace: "./", "" %}
+{% assign pagePath = page.inputPath | replace: "./", "" | replace: "_guides", "guides" %}
 <a
   data-toggle="tooltip"
   data-placement="top"

--- a/docs/_includes/edit_button.html
+++ b/docs/_includes/edit_button.html
@@ -1,9 +1,8 @@
-{% assign pagePath = page.inputPath | replace: "./", "" | replace: "_guides", "guides" %}
 <a
   data-toggle="tooltip"
   data-placement="top"
   title="Edit this on Github"
   class="icon-edit"
-  href="{{ site.github.repository_url }}/edit/master/docs/{{ pagePath }}"
+  href="{{ site.github.repository_url }}/edit/master/docs/{{ page.inputPath | formatInputPath }}"
   target="_blank"
 ></a>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -69,12 +69,14 @@
 
         <div class="container">
 
-          <h1 class="margin-bottom-none">{{ title }}</h1>
-          {% if edit != false %}
-            <span class="h1 margin-bottom-none">
+          <h1 class="margin-bottom-none">{{ title }}
+
+            {% if edit != false %}
+            <span>
               {% include edit_button.html %}
             </span>
-          {% endif %}
+            {% endif %}
+          </h1>
           {% if sub_title %}
             <h4>{{ sub_title}}</h4>
           {% endif %}

--- a/docs/eleventy.config.js
+++ b/docs/eleventy.config.js
@@ -18,7 +18,9 @@ module.exports = eleventyConfig => {
   eleventyConfig.addGlobalData('permalink', '/{{ page.filePathStem }}.html');
 
   eleventyConfig.addCollection('guides', collectionApi => {
-    return collectionApi.getFilteredByTag('guides').sort((a, b) => a.data.index - b.data.index);
+    return collectionApi
+        .getFilteredByTag('guides')
+        .sort((a, b) => a.data.index - b.data.index);
   });
 
   eleventyConfig.addCollection('pages', collectionApi => {
@@ -41,6 +43,10 @@ module.exports = eleventyConfig => {
     return collectionApi
         .getFilteredByTag('posts')
         .sort((a, b) => b.date - a.date || b.inputPath.localeCompare(a.inputPath));
+  });
+
+  eleventyConfig.addFilter("formatInputPath", function(value) {
+    return value.replace("./", "").replace("_guides", "guides").replace("_posts", "post");
   });
 
   eleventyConfig.addFilter('first_paragraph', function(content) {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that PouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     PouchDB committer.

     Artificial Intelligence and Large Language Models Contributions Policy

     It is expressly forbidden to contribute material generated by
     AI, LLMs, and similar technologies, to the PouchDB project. 
     This includes, but is not limited to, source code, documentation,
     commit messages, or any other areas of the project.

-->

## Overview

<!-- Please give a summary of the pull request,
     what problem it solves or how it makes things better. -->

The edit icon links to a 404 when you are at 'guides':

<img width="555" height="122" alt="image" src="https://github.com/user-attachments/assets/ff1095cc-6c3a-42b0-820a-c6421eabc1a5" />

This PR fixed the link to the GitHub markdown pages and shows the icon on the same line as the title.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] I am not a bot
- [ ] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation
- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Documentation changes were made in the `docs` folder
