### PR TITLE
ci: avoid azure mirrors if possible

### DIFF
--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -83,11 +83,14 @@ pouchdb-build-node() {
 }
 
 if [[ $CI = true ]] && [[ $CLIENT != node ]]; then
-  # npx playwright install --with-deps "$CLIENT"
-  # The full install with deps was glacially slow on CI 
-  npx playwright install "$CLIENT"
-  sudo apt-get update
-  sudo apt-get install -y libwoff1 libvpx9 libevent-2.1-7t64 libopus0 libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0 libflite1 libavif16 libharfbuzz-icu0 libsecret-1-0 libhyphen0 libwayland-server0 libmanette-0.2-0 libgles2 gstreamer1.0-libav
+  # Change Ubuntu mirror priorities. 
+  # azure.archive.ubuntu.com is very slow, especially if the US is awake.
+  # From https://github.com/servo/servo/pull/39190
+  sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
+  sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
+  sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
+  sudo cat /etc/apt/apt-mirrors.txt
+  npx playwright install --with-deps "$CLIENT"
 fi
 
 if [[ -n $SERVER ]]; then


### PR DESCRIPTION
## Overview

Avoid the Azure Ubuntu mirrors if possible, since they can slow down CI immensely. Other project also do this, this particular PR is inspired by: https://github.com/servo/servo/pull/39190

I've added this change directly in the `bin/run-test.sh` file just before we install Playwright, which is where all these dependencies come from. We previously tried doing this in the GH workflow yaml, but that didn’t take, maybe this approach is better. 

This PR also reverts my previous attempt at speeding this process up by installing fewer dependencies for Playwright, but that turned out to not have any effect.

## Testing recommendations

Trigger a CI run and compare it to a `master` run _at about the same time of day_ (important!).

## Measurements

First comparison against an unimproved branch:

Today at 10:35 AM -> 11:43 AM (old -> This PR)
 47m 39s -> 14m 44s

Slowest tests:

`couchdb-browser (3.1, firefox, TYPE=mapreduce ADAPTERS=http npm test)`
21m 19s	-> 1m 35s	
`browser-adapter (firefox, idb, npm test)`
22m 35s	-> 5m 21s	
`browser-adapter (webkit, memory, TYPE=find PLUGINS=pouchdb-find npm test)`
18m 28s -> 1m 21s	
`browser-adapter (firefox, idb, TYPE=find PLUGINS=pouchdb-find npm test)`
47m 8s -> 2m 7s	 

## Checklist

- [x] I am not a bot
- [x] This is my own work, I did not use AI, LLM's or similar technology for code or docs generation
- [x] Code is written and works correctly
- [ ] Changes are covered by tests -> Not applicable
- [ ] Documentation changes were made in the `docs` folder -> Not applicable

